### PR TITLE
Fix alphabetical order and placeholder text on supporter list

### DIFF
--- a/templates/custom/supporters.html
+++ b/templates/custom/supporters.html
@@ -30,7 +30,7 @@
         {% component_block "page_intro" %}
           {% fill "column_one" %}
             <p class="lead text-white">The OLH is supported by an international
-            network of library partners.</p>
+            network of {{ supporters.count }} library partners.</p>
           {% endfill %}
           {% fill "column_two" %}
             <p>Our supporters share our mission of returning academic journals
@@ -45,9 +45,9 @@
       <div class="relative mt-28">
         {% include 'custom/camera-man-bun-halfway.html' %}
         {% component_block "page_section" anchor="right" labelledby="supporters-by-country" %}
-          <h2 id="supporters-by-country" class="w-full">Supporters by country.</h2>
+          <h2 id="supporters-by-country" class="w-full">Find a supporter.</h2>
           {% component_block "filterable_list" list_id="supporters" value_names="country supporter" placeholder="e.g. Birkbeck" %}
-            {% regroup supporters by country as supporter_list %}
+            {% regroup supporters|dictsort:"country_name" by country as supporter_list %}
             <div class="list">
               {% for country, supporters_in_country in supporter_list %}
                 {% if country %}


### PR DESCRIPTION
Closes #397.
Closes #369.

**Note that this is dependent on https://github.com/openlibhums/consortial_billing/pull/79.**

Also adds supporter count to blue box at top of page.

![image](https://github.com/user-attachments/assets/8ad9f700-dceb-44da-ad47-da7f11e323ff)
![image](https://github.com/user-attachments/assets/2a1de504-2a3e-4111-ad67-0baa30b02f5e)
![image](https://github.com/user-attachments/assets/e08f5d33-dc03-4219-92ed-a93397046ae2)
