### PR TITLE
Artwork and edits for Recommend Us page

### DIFF
--- a/components/form/button-group.html
+++ b/components/form/button-group.html
@@ -1,5 +1,5 @@
 {% load component_tags %}
 
-<div class="w-full flex pt-4 items-start gap-4">
+<div class="w-full flex pt-4 items-start gap-4 flex-wrap">
   {% slot "buttons" default %}{% endslot %}
 </div>

--- a/components/form/button.html
+++ b/components/form/button.html
@@ -59,6 +59,9 @@
     thisButton.classList.remove('text-white');
     if (thisButton.hasAttribute('aria-controls')) {
       thisButton.setAttribute('aria-expanded', 'true');
+      const controlledId = thisButton.getAttribute('aria-controls');
+      const controlledElement = document.querySelector(`#${controlledId}`);
+      controlledElement.scrollIntoView({ behavior: 'smooth'});
     }
   })
 </script>

--- a/components/timeline/section.py
+++ b/components/timeline/section.py
@@ -16,7 +16,7 @@ class TimelineSection(component.Component):
 
     def get_context_data(self, alternate, *args, **kwargs):
         step = kwargs.pop('step', '')
-        bg = kwargs.pop('bg', 'bg-tan')
+        bg = kwargs.pop('bg', 'bg-white')
         context = super().get_context_data(*args, **kwargs)
         context['alternate'] = alternate
         context['step'] = step

--- a/templates/custom/recommend-us-choose-article.html
+++ b/templates/custom/recommend-us-choose-article.html
@@ -27,17 +27,17 @@
           </ul>
         </div>
         <p>Can’t find the article?</p>
-        {% component_block "button_group"  %}
-          {% url 'recommend_us_generate_email' as hx_post %}
-          {% component_block "button" name="general" hx_post=hx_post aria_controls=aria_controls %}
-            Get a general email
-          {% endcomponent_block %}
-        {% endcomponent_block %}
       {% else %}
         <h2 class="text-white">No matches for “{{ query }}”.</h2>
         <p>We couldn't find an article with that title. Please try modifying
         your query or generate a generic template.</p>
       {% endif %}
+      {% component_block "button_group"  %}
+        {% url 'recommend_us_generate_email' as hx_post %}
+        {% component_block "button" name="general" hx_post=hx_post aria_controls=aria_controls %}
+          Get a general email
+        {% endcomponent_block %}
+      {% endcomponent_block %}
     {% endcomponent_block %}
   </div>
 {% endcomponent_block %}

--- a/templates/custom/recommend-us-choose-article.html
+++ b/templates/custom/recommend-us-choose-article.html
@@ -15,11 +15,11 @@
           <ul>
             {% for article in articles %}
               <li class="list-none mt-4">
-                <div>{{ article.how_to_cite }}</div>
+                <div>{{ article.how_to_cite|safe }}</div>
                 {% component_block "button_group"  %}
                   {% url 'recommend_us_generate_email' as hx_post %}
                   {% component_block "button" name="article_pk" value=article.pk hx_post=hx_post aria_controls=aria_controls %}
-                    Use {{ article.title|truncatewords_html:3 }}
+                    Use {{ article.title|truncatewords_html:3|safe }}
                   {% endcomponent_block %}
                 {% endcomponent_block %}
               </li>

--- a/templates/custom/recommend-us-choose-journal.html
+++ b/templates/custom/recommend-us-choose-journal.html
@@ -9,7 +9,9 @@
       <input hidden name="role" value="{{ role }}">
       {% if journal_names %}
         {% with journal_count=journal_names.count %}
-          <h2 class="text-white">Journal{{ journal_count|pluralize }} with “{{ query }}”.</h2>
+          <h2 class="text-white">
+            Journal{{ journal_count|pluralize }} with “{{ query }}”.
+          </h2>
         {% endwith %}
         <div class="not-prose">
           <ul>
@@ -27,17 +29,17 @@
           </ul>
         </div>
         <p>Can’t find your journal?</p>
-        {% component_block "button_group"  %}
-          {% url 'recommend_us_generate_email' as hx_post %}
-          {% component_block "button" name="general" hx_post=hx_post aria_controls=aria_controls %}
-            Get a general email
-          {% endcomponent_block %}
-        {% endcomponent_block %}
       {% else %}
         <h2 class="text-white">No matches for “{{ query }}”.</h2>
         <p>We couldn't find a journal matching your search. Please try modifying
         your search terms or generate a generic template.</p>
       {% endif %}
+      {% component_block "button_group"  %}
+        {% url 'recommend_us_generate_email' as hx_post %}
+        {% component_block "button" name="general" hx_post=hx_post aria_controls=aria_controls %}
+          Get a general email
+        {% endcomponent_block %}
+      {% endcomponent_block %}
     {% endcomponent_block %}
   </div>
 {% endcomponent_block %}

--- a/templates/custom/recommend-us-choose-role.html
+++ b/templates/custom/recommend-us-choose-role.html
@@ -3,9 +3,10 @@
 
 {% get_uuid4 as aria_controls %}
 {% component_block "timeline_section" alternate="odd" step=step bg="bg-blue" %}
-  <h2 class="text-white">How do you know the OLH?</h2>
+  <h2 class="text-white">How do you know about the OLH?</h2>
   <form method="POST">
     {% csrf_token %}
+    <p class="text-white">Are you an...<p>
     <div class="w-full flex flex-wrap gap-4 pt-4 items-center">
       <div class="w-48">
         {% url 'recommend_us_search_article' as hx_post %}

--- a/templates/custom/recommend-us-confirm-sent.html
+++ b/templates/custom/recommend-us-confirm-sent.html
@@ -1,0 +1,13 @@
+{% load component_tags %}
+{% load humanize %}
+
+{% component_block "timeline_section" alternate="odd" step=step bg="bg-blue" %}
+  <div class="text-white">
+    <h2 class="text-white">Thank you for supporting open access.</h2>
+    <p>Library support has helped us to make over 
+    {{ request.press.published_articles.count|intcomma }} articles
+    diamond open access so far, saving university libraries an estimated £33.9
+    million since 2015. By recommending us to your librarian, you are helping to keep
+    knowledge free. Thank you.</p>
+  </div>
+{% endcomponent_block %}

--- a/templates/custom/recommend-us-confirm-sent.html
+++ b/templates/custom/recommend-us-confirm-sent.html
@@ -1,6 +1,8 @@
 {% load component_tags %}
 {% load humanize %}
+{% load uuid %}
 
+{% get_uuid4 as copy_pid %}
 {% component_block "timeline_section" alternate="odd" step=step bg="bg-blue" %}
   <div class="text-white">
     <h2 class="text-white">Thank you for supporting open access.</h2>
@@ -9,5 +11,25 @@
     diamond open access so far, saving university libraries an estimated £33.9
     million since 2015. By recommending us to your librarian, you are helping to keep
     knowledge free. Thank you.</p>
+    <p>One more thing... Please share this page on social media so others
+    recommend us.</p>
+    {% component_block "button_group" %}
+      {% component_block "button" name="general" id=copy_pid type="button" %}
+        Copy link to this page
+      {% endcomponent_block %}
+    {% endcomponent_block %}
   </div>
+  <script defer type="module">
+    const copyButton = document.querySelector('#{{ copy_pid }}');
+    copyButton.addEventListener('click', () => writeToClipboard(window.location.href));
+    async function writeToClipboard(text) {
+      try {
+        await navigator.clipboard.writeText(text);
+        copyButton.querySelector('span').innerHTML = 'Copied';
+        copyButton.querySelector('svg').remove();
+      } catch {
+        return
+      }
+    }
+  </script>
 {% endcomponent_block %}

--- a/templates/custom/recommend-us-generate-email.html
+++ b/templates/custom/recommend-us-generate-email.html
@@ -56,7 +56,7 @@
       try {
         copyButton.querySelector('span').innerHTML = 'Copied';
         copyButton.querySelector('svg').remove();
-      } except {
+      } catch {
         return
       }
     }

--- a/templates/custom/recommend-us-generate-email.html
+++ b/templates/custom/recommend-us-generate-email.html
@@ -7,7 +7,12 @@
 {% component_block "timeline_section" alternate="even" step=step bg="bg-blue" %}
   <div>
     <h2 class="text-white">Voilà.</h2>
-    <p class="text-white">Here is an email to send to your librarian.</p>
+    <p class="text-white">Here is an email to send to your library. Just copy
+    and paste this text into an email to your librarian to help us reach them.
+    You should be able to find your library’s contact email address on your
+    institution’s website. If you’re having problems finding the right email
+    address, <a class="text-white" href="/contact/">contact us</a> and we’ll
+    help.</p>
     <div class="text-black bg-white p-6 font-space-mono-regular">
       <div id="email-text">
         {{ email }}
@@ -39,7 +44,7 @@
       {% component_block "button_group" %}
         {% url 'recommend_us_confirm_sent' as hx_post %}
         {% component_block "button" hx_post=hx_post aria_controls=aria_controls %}
-          I've emailed my library
+          I’ve emailed my library
         {% endcomponent_block %}
       {% endcomponent_block %}
     {% endcomponent_block %}

--- a/templates/custom/recommend-us-generate-email.html
+++ b/templates/custom/recommend-us-generate-email.html
@@ -19,6 +19,15 @@
         {% component_block "button" name="general" id=pid type="button" %}
           Copy to clipboard
         {% endcomponent_block %}
+        <a
+          class="
+            p-4 not-prose
+            border rounded-full border-white
+            flex gap-4 items-center
+          "
+          href="mailto:?subject=Joining the OLH&body={{ email|striptags|urlencode }}">
+          {% include "custom/button-action-inner-white.html" with label="Open in email" %}
+        </a>
         {% url "recommend_us" as rel_path %}
         {% include "custom/button-action-white.html" with rel_path=rel_path label="Start over" %}
       {% endcomponent_block %}

--- a/templates/custom/recommend-us-generate-email.html
+++ b/templates/custom/recommend-us-generate-email.html
@@ -2,7 +2,8 @@
 {% load component_tags %}
 {% load uuid %}
 
-{% get_uuid4 as pid %}
+{% get_uuid4 as copy_pid %}
+{% get_uuid4 as aria_controls %}
 {% component_block "timeline_section" alternate="even" step=step bg="bg-blue" %}
   <div>
     <h2 class="text-white">Voilà.</h2>
@@ -14,9 +15,10 @@
     </div>
   </div>
   <div class="flex mt-6">
-    {% component_block "form" notify_required=False default_button=False %}
+    {% component_block "form" form_method="POST" notify_required=False default_button=False %}
+      <input hidden name="previous_step" value="{{ step }}">
       {% component_block "button_group" %}
-        {% component_block "button" name="general" id=pid type="button" %}
+        {% component_block "button" name="general" id=copy_pid type="button" %}
           Copy to clipboard
         {% endcomponent_block %}
         <a
@@ -25,25 +27,39 @@
             border rounded-full border-white
             flex gap-4 items-center
           "
+          target="_blank"
+          rel="noopener"
           href="mailto:?subject=Joining the OLH&body={{ email|striptags|urlencode }}">
           {% include "custom/button-action-inner-white.html" with label="Open in email" %}
         </a>
         {% url "recommend_us" as rel_path %}
         {% include "custom/button-action-white.html" with rel_path=rel_path label="Start over" %}
       {% endcomponent_block %}
+      <p class="text-white">Have you sent the email to your library?</p>
+      {% component_block "button_group" %}
+        {% url 'recommend_us_confirm_sent' as hx_post %}
+        {% component_block "button" hx_post=hx_post aria_controls=aria_controls %}
+          I've emailed my library
+        {% endcomponent_block %}
+      {% endcomponent_block %}
     {% endcomponent_block %}
   </div>
   <script defer type="module">
     const emailText = document.querySelector('#email-text');
-    const copyButton = document.querySelector('#{{ pid }}');
+    const copyButton = document.querySelector('#{{ copy_pid }}');
     copyButton.addEventListener('click', () => setClipboard(emailText.innerHTML));
     async function setClipboard(text) {
       const type = "text/html";
       const blob = new Blob([text], { type });
       const data = [new ClipboardItem({ [type]: blob })];
       await navigator.clipboard.write(data);
-      copyButton.querySelector('span').innerHTML = 'Copied';
-      copyButton.querySelector('svg').remove();
+      try {
+        copyButton.querySelector('span').innerHTML = 'Copied';
+        copyButton.querySelector('svg').remove();
+      } except {
+        return
+      }
     }
   </script>
 {% endcomponent_block %}
+<div id="{{ aria_controls }}"></div>

--- a/templates/custom/recommend-us-search-journal.html
+++ b/templates/custom/recommend-us-search-journal.html
@@ -12,8 +12,10 @@
     {% endcomponent_block %}
     <input hidden name="role" value="{{ role }}">
     {% url 'recommend_us_choose_journal' as hx_post %}
-    {% component_block "button" hx_post=hx_post aria_controls=aria_controls %}
-      Search
+    {% component_block "button_group" %}
+      {% component_block "button" hx_post=hx_post aria_controls=aria_controls %}
+        Search
+      {% endcomponent_block %}
     {% endcomponent_block %}
   {% endcomponent_block %}
 {% endcomponent_block %}

--- a/templates/custom/recommend-us-see-matching-supporters.html
+++ b/templates/custom/recommend-us-see-matching-supporters.html
@@ -14,10 +14,11 @@
           </li>
         {% endfor %}
       </ul>
+      <p>If your library is not here, they are not a member yet... Help us reach them!</p>
     {% else %}
       <h2 class="text-white">No matches for “{{ query }}”.</h2>
+      <p>It looks like your library isn’t an OLH supporter yet... Help us reach them!</p>
     {% endif %}
-    <p>If your library is not here, they are not a member yet... Help us reach them!</p>
     <p>Fill in your details to generate a template email to your library.</p>
     {% component_block "form" form_method="POST" notify_required=False default_button=False %}
       {% component_block "button_group"  %}

--- a/templates/custom/recommend-us.html
+++ b/templates/custom/recommend-us.html
@@ -21,10 +21,10 @@
 
 {% block body %}
   <div class="container mx-auto max-w-screen-xl">
-    <div class="relative max-lg:mt-52 lg:top-0">
+    <div class="relative max-lg:mt-56 lg:mt-8">
       {% include 'custom/edit-on-github.html' with rel_path='custom/recommend-us.html' %}
-      {#{% include 'custom/astrolabe-opener.html' %}#}
-      {% include 'custom/generic-h1.html' with h1="Recommend us." %}
+      {% include "custom/typewriter-opener.html" %}
+      {% include 'custom/generic-h1.html' with h1="Recommend<br> us." %}
     </div>
     <div class="relative">
       {% get_uuid4 as aria_controls %}
@@ -44,7 +44,7 @@
           {% endcomponent_block %}
         {% endcomponent_block %}
       {% endcomponent_block %}
-      <div id="{{ aria_controls }}"></div>
+      <div id="{{ aria_controls }}" class="min-h-48"></div>
     </div>
     {% include "custom/subscribe.html" %}
   </div>


### PR DESCRIPTION
Makes changes listed in #405 as well as fixing a bug I introduced on the open access movement page, where the white and light tan backgrounds went away on the timeline.

Relies on https://github.com/openlibhums/consortial_billing/pull/84.

Closes #405.