### PR TITLE
Mark old themed account pages as deprecated

### DIFF
--- a/templates/core/accounts/activate_account.html
+++ b/templates/core/accounts/activate_account.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n %}
 

--- a/templates/core/accounts/edit_profile.html
+++ b/templates/core/accounts/edit_profile.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n roles %}
 

--- a/templates/core/accounts/get_reset_token.html
+++ b/templates/core/accounts/get_reset_token.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n %}
 

--- a/templates/core/accounts/login.html
+++ b/templates/core/accounts/login.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n %}
 {% load orcid %}

--- a/templates/core/accounts/orcid_registration.html
+++ b/templates/core/accounts/orcid_registration.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n %}
 {% load static %}

--- a/templates/core/accounts/public_profile.html
+++ b/templates/core/accounts/public_profile.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 
 {% load component_tags %}

--- a/templates/core/accounts/register.html
+++ b/templates/core/accounts/register.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n %}
 {% load static %}

--- a/templates/core/accounts/reset_password.html
+++ b/templates/core/accounts/reset_password.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% extends "core/base.html" %}
 {% load i18n %}
 {% load materializecss %}

--- a/templates/custom/activate-account.html
+++ b/templates/custom/activate-account.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 

--- a/templates/custom/get-reset-token.html
+++ b/templates/custom/get-reset-token.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 {% load orcid %}

--- a/templates/custom/login.html
+++ b/templates/custom/login.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 {% load orcid %}

--- a/templates/custom/orcid-registration.html
+++ b/templates/custom/orcid-registration.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 

--- a/templates/custom/profile.html
+++ b/templates/custom/profile.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 

--- a/templates/custom/register.html
+++ b/templates/custom/register.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 

--- a/templates/custom/reset-password.html
+++ b/templates/custom/reset-password.html
@@ -1,3 +1,7 @@
+{% comment %}
+  This template is deprecated. Account pages are now part of the back-office.
+{% endcomment %}
+
 {% load static %}
 {% load component_tags %}
 


### PR DESCRIPTION
Contributes to openlibhums/janeway#4380.

- [ ] Deprecate the templates in `/core/accounts/`, not just the ones in `/custom/`.