### PR TITLE
Fixed the public profile template for use in 1.7.x

### DIFF
--- a/templates/core/accounts/public_profile.html
+++ b/templates/core/accounts/public_profile.html
@@ -1,10 +1,11 @@
+{% extends "core/base.html" %}
+{% load component_tags %}
+
 {% comment %}
   This template is deprecated. Account pages are now part of the back-office.
 {% endcomment %}
 
-{% extends "core/base.html" %}
 
-{% load component_tags %}
 
 {% block title %}
   {{ user.full_name }} - {{ request.press.name }}


### PR DESCRIPTION
The `{% extends %}` tag must always be first, so I've shifted the comment down for now.